### PR TITLE
Rename deployment in order to rename pods

### DIFF
--- a/k8s/templates/autoscaler.yaml
+++ b/k8s/templates/autoscaler.yaml
@@ -7,7 +7,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Values.name }}
+    name: {{ .Values.namespace }}
   minReplicas: {{ .Values.hpa_min }}
   maxReplicas: {{ .Values.hpa_max }}
   metrics:

--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Values.namespace }}
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}

--- a/k8s/templates/ingress.yml
+++ b/k8s/templates/ingress.yml
@@ -12,5 +12,5 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ .Values.name }}
+          serviceName: {{ .Values.namespace }}
           servicePort: 80

--- a/k8s/templates/service.yml
+++ b/k8s/templates/service.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Values.namespace }}
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}


### PR DESCRIPTION
When forwarding logs to papertrail, this will help us divide the logs by environment