### PR TITLE
upgrade k8s deprecated ingress api extensions/v1beta1

### DIFF
--- a/k8s/templates/ingress.yml
+++ b/k8s/templates/ingress.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.name}}-nginx-ingress


### PR DESCRIPTION
JIRA ticket: https://jira.mozilla.com/browse/SE-1738

What this PR does: updates the kubernetes ingress API used to avoid being deprecated by the kubernetes 1.15 => 1.16 upgrade.

Notes:
* to deploy this after merge, need to go run the CodeBuild pipelines manually for dev, stage & prod environments
* alternatively, if we don't want to rebuild the full pipeline, could use helm (this is pinned to helm version 2) to generate the k8s yaml & manually apply to each environment - this avoids rebuilding the docker image.
* pinging devs on this as well to alert them to the what is going on
* we should add a backlog ticket to handle the hard helm v2 requirement used in these codebuild pipelines, since that is also deprecated