### PR TITLE
disable manual deploys from tagging images with full commit SHA

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -83,7 +83,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
       - name: Build and Push Stage Image to ECR
         id: build-push
-        if: github.ref == 'refs/heads/master'
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: discourse
@@ -101,20 +100,8 @@ jobs:
           ./launcher bootstrap app
           docker tag local_discourse/app:latest $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-      - name: Pull Stage Image, Tag Prod, & Push Prod to ECR
-        id: pull-tag-push
-        if: github.event_name == 'release' && github.event.action == 'released'
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: discourse
-          ENV: ${{ needs.prepare.outputs.ENV }}
-          TAG: ${{ needs.prepare.outputs.TAG }}
-        run: |
-          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$GITHUB_SHA
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$GITHUB_SHA
       - name: Logut of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/manual_delivery.yaml
+++ b/.github/workflows/manual_delivery.yaml
@@ -98,8 +98,6 @@ jobs:
           ./launcher bootstrap app
           docker tag local_discourse/app:latest $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$ENV-$TAG $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
       - name: Logut of Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/discourse-prod.yml
+++ b/discourse-prod.yml
@@ -23,16 +23,16 @@ hooks:
         cd: $home/plugins
         cmd:
           - mkdir -p plugins
-          - git clone https://github.com/discourse/discourse-akismet.git
-          - git clone https://github.com/mozilla/discourse-mozilla-iam.git
-          - git clone https://github.com/mozilla/discourse-expose-emails-in.git
-          - git clone https://github.com/mozilla/discourse-post-read-email.git
-          - git clone https://github.com/discourse/discourse-solved.git
-          - git clone https://github.com/mozilla/discourse-sidekiq-monitor.git
-          - git clone https://github.com/mozilla/discourse-mozilla-letter-avatar.git
-          - git clone https://github.com/mozilla/discourse-auto-email-in
-          - git clone https://github.com/mozilla/discourse-group-category-notification.git
-          - git clone https://github.com/mozilla/discourse-mozilla-gcm
+          - git clone https://github.com/discourse/discourse-akismet.git # 11ef295b5c65684f00ccf55cb4bef5656cd0ba9b
+          - git clone https://github.com/mozilla/discourse-mozilla-iam.git # f66123785a02a67ca10d13649cea00c772f7e40a
+          - git clone https://github.com/mozilla/discourse-expose-emails-in.git # e4e92b02bd150c72585eba232a27aa4bf9e7f5fb
+          - git clone https://github.com/mozilla/discourse-post-read-email.git # 0031da69216ba759cbf5cdda4ff4ad818e4a617f
+          - git clone https://github.com/discourse/discourse-solved.git # 02981fe1d9463cee4d8f64228a74da21fc38d90b
+          - git clone https://github.com/mozilla/discourse-sidekiq-monitor.git # 34178b637ea508d2ef103b6d48d2e0c21af155dd
+          - git clone https://github.com/mozilla/discourse-mozilla-letter-avatar.git # a5cc90fdafe523a21b5b54abe63d7798efe77b49
+          - git clone https://github.com/mozilla/discourse-auto-email-in # ca205f63e8b8852154fddd30bf09c994070727e2
+          - git clone https://github.com/mozilla/discourse-group-category-notification.git # 8be0c45e8a19c4c702a8a468e882d9968a967ee9
+          - git clone https://github.com/mozilla/discourse-mozilla-gcm # 1d15d63e6dca4d33f1ea38c9eb2395034c467ef2
 run:
   - exec: echo "Beginning of custom commands"
   ## If you want to set the 'From' email address for your first registration, uncomment and change:


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2508

What this PR does:
* disables tagging of manual delivery pipeline-generated Docker images with the full Commit SHA
* images tagged with full commit SHA are limited to use by Gitflow-automated stage & production images, so only images that have gone through stage are promoted to production
* This also means you can run manual delivery pipeline only for dev & stage environments, but you cannot run it for prod / none of the images from those pipelines will ever be looked up for promotion to prod.