### PR TITLE
chore(rsyslog): Noticed an error on host startup

### DIFF
--- a/includes/moz.web.template.yml
+++ b/includes/moz.web.template.yml
@@ -31,6 +31,7 @@ run:
   - exec: chown -R discourse /home/discourse
   # TODO: move to base image (anacron can not be fired up using rc.d)
   - exec: rm -f /etc/cron.d/anacron
+  - exec: sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
   - file:
      path: /etc/cron.d/anacron
      contents: |


### PR DESCRIPTION
Error I was seeing is:
```bash
│ discourse rsyslogd: imklog: cannot open kernel log (/proc/kmsg): Operation not permitted.                                                                                                                                                                    │
│ discourse rsyslogd: activation of module imklog failed [v8.1901.0 try https://www.rsyslog.com/e/2145 ]
```

I got around this in kubernetes by using postStart:
```yaml
        lifecycle:                            
          postStart:                      
            exec:                                                                                                               
              command:            
              - sh
              - -c   
              - sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 ```